### PR TITLE
Multiple risks on country perfomance page

### DIFF
--- a/public/static/css/site.css
+++ b/public/static/css/site.css
@@ -9135,3 +9135,6 @@ header.navigation {
             padding-left: 1em;
             text-align: left;
             width: 12em; } }
+#root h3 {
+  color: #00D49A;
+}

--- a/views/place.html
+++ b/views/place.html
@@ -10,108 +10,13 @@
 {% endblock breadcrumbs_inner %}
 
 {% block content %}
-<section id="data-header">
-  <div class="row">
-    <div class="col-md-6">
-      <h1>
-        <a href="/country/{{ options[0].slug }}/">{{ options[0].name }}</a>
-      </h1>
-      <div class="table-responsive">
-        <table id="places_overview_table" class="table data-table table-header-stuck">
-          <col style="width:30%">
-          <col style="width:25%">
-          <col style="width:20%">
-          <col style="width:25%">
-          <thead>
-            <tr>
-              <th>Risk</th>
-              <th>Previous</th>
-              <th>Count</th>
-              <th>Amplified Count</th>
-            </tr>
-          </thead>
-          <tbody>
-          {% for option in options %}         
-            <tr data-rank="{{ option.rank }}" data-score="{{ option.score }}" data-place="{{ option.place }}">
-              <td>
-								{% if option.slug %}
-                  <a href="/country/{{ option.slug }}/{{option.risk_slug}}/">{{ option.risk_title }}</a>
-								{% else %}
-									<a>{{ option.risk_title }}</a>
-								{% endif %}
-              </td>
-              <td class="previous-results">
-              {% if option.previous and option.previous.score %}
-                  <span class="rank rank-previous">#{{ option.previous.rank }}</span>&nbsp;&nbsp;<span class="score score-previous" data-score="{{ option.previous.score }}">{{ option.previous.score }}%</span>
-              {% else %}
-                  N/A
-              {% endif %}
-              </td>
-              <td>
-                <span>{{ option.count or "N/A"}} </span>
-              </td>
-              <td>
-                <span>{{ option.count_amplified or "N/A"}} </span>
-              </td>
-            </tr>
-          {% endfor %}
-          </tbody>
-        </table>
-      </div>
-			<div class="row navigate">
-				<div class="col-md-6">
-					{{ share(map) }}
-				</div>
-			</div> 
-		</div>
-    <div class="col-md-6">
-      <div id="map-container">
-        {% include 'dataviews/embed_map.html' %}
-      </div>
-    </div>
+  <div class="col-md-6">
+    <script>
+      var countries = {{countries}}
+      var countryPerformanceOnRiskViews = {{countryPerformanceOnRiskViews}}
+    </script>
+    <div id="root"></div>
+    <script type="text/javascript" src="/static/vendor/cg-graphs/index.min.js"></script>
   </div>
-  <br>
-  {% for risk in riskOpt %}
-  	<div id="treemap{{risk.slug}}"></div>
-  {% endfor %}
-  <script type="text/javascript">var treeAsn = {{ treeAsn }}</script>
-  <script type="text/javascript" src="/static/scripts/treemap.js"></script>
-  <div class="table-responsive">
-		<table id="places_overview_table" class="table data-table table-header-stuck">
-		  <thead>
-				<tr>
-				  <th>ASN</th>
-				  {% for risk in riskOpt %}
-			      <th>
-			        {{ risk.title }}
-			      </th>
-						<th>
-			        {{ risk.title }} AF
-			      </th>
-				  {% endfor %}
-				</tr>
-			</thead>
-			<tbody>
-			{% for asn in asns %}
-				<tr>
-				  <td class="sort_place" title="Sort by A-Z">  
-				    <a href="/country/{{ options[0].slug }}/asn/{{ asn.asn }}/" title="{{ asn.asn }}">
-				      {{ asn.asn or 'N/A'}}
-				    </a>
-				  </td>
-				  {% for risk in riskOpt %}
-				    <td class="sort_place" title="Sort by A-Z">
-				      <span>{{ asn[risk.id].count or 'N/A'}}</span>
-				    </td>
-						<td class="sort_place" title="Sort by A-Z">
-				      <span>{{ asn[risk.id].af_count or 'N/A'}}</span>
-				    </td>
-				  {% endfor %}
-				</tr>
-			{% endfor %}
-			</tbody>
-		</table>
-	</div>
-</section>
 
 {% endblock content %}


### PR DESCRIPTION
After this PR old layout of county page is changed with new, multiple time series graphs for each risk. with ability compare "my" country to any available country on demand.
Entire page is served in React by application build in https://github.com/cybergreen-net/cg-graps repo. 
Most of the changes are done in this milestone https://github.com/cybergreen-net/cg-graphs/milestone/1?closed=1

PR include:
- changes in routes. Not a single calculation is happening in back end any more except getting list of countries and risk from DB and building graph `views` for each graph
- Template for country page includes only one `<div>` element with root of id that is used  by React app
- some css tidy
- submodule update 